### PR TITLE
Sanitize Codesearch query text for regex

### DIFF
--- a/codesearch.js
+++ b/codesearch.js
@@ -322,7 +322,7 @@ function generateHtmlForCodeSearchEntry(data, url, searchTerm, statisticsObj) {
       jQuery.each(match.lineMatches, function (ix, fieldMatch) {
         statisticsObj.lines += 1;
         var fieldMatchHighlighted = fieldMatch.escaped.replace(
-          new RegExp(htmlEntities(searchTerm), 'gi'),
+          new RegExp(escapeSearchRegex(searchTerm), 'gi'),
           function (m) {
             return `<strong>${m}</strong>`;
           }
@@ -474,6 +474,19 @@ function setDefaultGroubBySysId(sys_id) {
 
 function setGroupDescription(group) {
   $('#search_group_description').text(group.description);
+}
+
+function escapeSearchRegex(search_term) {
+  search_term = htmlEntities(search_term);
+  if (RegExp.escape) {
+    // use browser-provided regex escape function, if available
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape
+    search_term = RegExp.escape(search_term);
+  } else {
+    // otherwise, manually escape special characters
+    search_term = search_term.replace(/(\\|\(|\)|\[\]|\.)/g, m => '\\'+m);
+  }
+  return search_term;
 }
 
 function htmlEntities(str) {


### PR DESCRIPTION
Fix #585  
Escapes the user-provided search string when highlighting results in the Codesearch tool to prevent errors caused by regex special characters.
Uses `RegExp.escape` when available, or a less powerful custom find-and-replace when not.

## Pull Request Checklist

Before submitting this PR, make sure the following are checked:
- [✔] I have discussed this contribution **beforehand** via GitHub Discussion, GitHub Issue, SN Devs Slack, or email.
- [✔] This PR is not a typo fix or other unsolicited minor change.
- [❌] This PR has been explicitly agreed upon beforehand.
- [✔] I understand that unaligned PRs will be closed without review.
- [✔] I understand that SN Utils is not released under an open source license and is owned by Arnoud Kooi.
- [✔] I have not altered the defintion of this checklist.

*edited 2025-06-17*